### PR TITLE
Loosen interpret_constraints configuration option

### DIFF
--- a/README.org
+++ b/README.org
@@ -3,7 +3,7 @@
 #+EMAIL:       engineering@sendwave.com
 #+DESCRIPTION: Node Plugin Documentation
 
-* Version 1.2.0
+* Version 1.2.1
 
 This package contains a plugin for the [[https://www.pantsbuild.org/][pants build system]] to run npm
 based scripts from pants build targets
@@ -24,7 +24,7 @@ as below,
 #+NAME: pants.toml
 #+BEGIN_SRC: toml
 [GLOBAL]
-plugins = ["sendwave-pants-node@https://GITHUB_RELEASE_URL"]
+plugins = ["sendwave-pants-node~=1.2"]
 backend_packages = ["sendwave.pants_node"]
 #+END_SRC
 
@@ -103,6 +103,9 @@ have reproducable builds, you may generate one by running:
 #+END_SRC
 
 * Changelog
+** 1.2.1
+2022-10-05
++ Relax interpret constraint to allow python >=3.8
 ** 1.2.0
 2022-10-04
 + Upgrade to use pants 2.13, no breaking changes in plugin

--- a/README.org
+++ b/README.org
@@ -10,7 +10,7 @@ based scripts from pants build targets
 
 *  Requirements
 
-This plugin supports pantsbuild 2.9 and requires python >=3.9 to be
+This plugin supports pantsbuild 2.9 and requires python >=3.8 to be
 installed. It also requires the [[https://github.com/compyman/pants-docker][pants-docker plugin]] so that a
 =npm_package= may be included as dependencies to docker
 images

--- a/pants.toml
+++ b/pants.toml
@@ -30,7 +30,7 @@ search_path = ["<PYENV>"]
 
 [python]
 tailor_pex_binary_targets = false
-interpreter_constraints = ["==3.9.*"]
+interpreter_constraints = [">=3.8"]
 
 
 [anonymous-telemetry]

--- a/pants_plugins/sendwave/pants_node/BUILD
+++ b/pants_plugins/sendwave/pants_node/BUILD
@@ -8,7 +8,7 @@ python_distribution(
     dependencies=[":pants_node_library"],
     provides=setup_py(
         name="sendwave-pants-node",
-        version="1.2.0",
+        version="1.2.1",
         description="Pants Plugin to build node bundles",
         url="https://github.com/waveremit/pants-node",
         author="Nathan Rosenbloom, Jean Cochrane",


### PR DESCRIPTION
I didn't realize when setting this that it was used to populate the
required interpreter version for any python_distribution targets! So I
mistakenly set it too strict. Setting it back to python 3.8 to not
force us to update to python 3.9 everywhere we are using pants
